### PR TITLE
Added Implementation Feature

### DIFF
--- a/SocialMedia.API/2_Controller/UserController.cs
+++ b/SocialMedia.API/2_Controller/UserController.cs
@@ -4,16 +4,23 @@ namespace SocialMedia.API.Controller;
 
 using SocialMedia.API.DTO;
 using SocialMedia.API.Service;
+using System.Security.Claims;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
 
 [Route("api/[controller]")]
 [ApiController]
 public class UserController : ControllerBase
 {
     private readonly IUserService _userService;
+    private readonly IConfiguration _configuration;
 
-    public UserController(IUserService userService)
+    public UserController(IUserService userService, IConfiguration configuration)
     {
         _userService = userService;
+        _configuration = configuration;
     }
 
     // POST: api/User
@@ -37,6 +44,7 @@ public class UserController : ControllerBase
     }
 
     // GET: api/User
+    [Authorize]
     [HttpGet]
     public async Task<IActionResult> GetAllUsers()
     {
@@ -112,7 +120,7 @@ public class UserController : ControllerBase
         if (string.IsNullOrWhiteSpace(userDto.Username))
             return BadRequest("Username cannot be empty.");
 
-        // 1) Look up user by username
+        // 1) Look up user by username //Update the GetUserByUsername in Controller with GetUserWithToken
         var user = await _userService.GetUserByUsername(userDto.Username)!;
         if (user == null)
             return NotFound("User not found.");
@@ -123,6 +131,30 @@ public class UserController : ControllerBase
             return Unauthorized("Invalid credentials.");
         }
 
-        return Ok(user);
+       
+        if(user != null)
+        {
+            var claims = new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, _configuration["Jwt:Subject"]!),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+                new Claim("UserId", user.Id.ToString()),
+                new Claim("Username", user.Username!.ToString())
+            };
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+            var signIn = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            var token = new JwtSecurityToken(
+                _configuration["Jwt:Issuer"],
+               _configuration["Jwt:Audience"],
+                claims,
+                expires: DateTime.UtcNow.AddMinutes(60),
+                signingCredentials: signIn
+            );
+            string tokenValue = new JwtSecurityTokenHandler().WriteToken(token);
+            return Ok(new { Token = tokenValue, User = user });
+        }
+        return NoContent();
     }
+
 }

--- a/SocialMedia.API/SocialMedia.API.csproj
+++ b/SocialMedia.API/SocialMedia.API.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">


### PR DESCRIPTION
Jwt Authentication being submitted for review. 

First: I only added annotations of [Authorize] to one method in the User controller. The reason Is because I know you have a design in place and may or may not want certain methods in the Tweet controller to have [Authorize] credentials. Plus the login method needs to have public access so users can generate the key and it's located in the Users controller so I didn't use [Authorize] on the class level for the Users controller either. This is because once again I'm sure your design that's in place can be customized how you see fit with the [Authorize] annotation.

Second: Use must add the user-secrets to your API. Each one of these items needs to be added separately to the user secrets for the code to work properly unless you have a different implementation for environment variables.
1:  "Jwt:Subject" "Jwt:Subject"
2. "Jwt:Issuer" "Jwt:Issuer"
3. 3. "Jwt:Audience" "Jwt:Audience"
4. "Jwt:Key" "Jkdieikdieidkei65858995958585949495984kdieidkei6585899595858594949"

If you have any questions before Monday ping me on teams, and I will respond for updates to the code.